### PR TITLE
feat(APPT-STQA-136): Add input validation to owner cancel form

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/web/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/OwnerController.java
@@ -153,21 +153,26 @@ public class OwnerController {
     }
 
     @PostMapping(value = "/owners/{ownerId}/appointments/cancel", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public String processCancelOwnerAppointmentForm(@RequestBody MultiValueMap<String, String> formData) {
+    public String processCancelOwnerAppointmentForm(@PathVariable int ownerId, @RequestBody MultiValueMap<String, String> formData) {
+        Collection<Visit> ownerVisits = clinicService.findVisitsByOwnerId(ownerId);
+
         List<Integer> visits = new ArrayList<>();
         formData.forEach((k, v) -> {
-            int visit;
+            int visitId;
             try {
-                visit = Integer.parseInt(k);
+                visitId = Integer.parseInt(k);
             } catch (NumberFormatException e) {
                 return;
             }
 
-            v.stream().findAny().ifPresent(answer -> {
-                if (answer.equals("on")) {
-                    visits.add(visit);
-                }
-            });
+            // only delete visits which actually belong to that owner
+            if (ownerVisits.stream().anyMatch(visit -> visit.getId() == visitId)) {
+                v.stream().findAny().ifPresent(answer -> {
+                    if (answer.equals("on")) {
+                        visits.add(visitId);
+                    }
+                });
+            }
         });
 
         if (!visits.isEmpty()) {

--- a/src/main/webapp/WEB-INF/jsp/pets/findPets.jsp
+++ b/src/main/webapp/WEB-INF/jsp/pets/findPets.jsp
@@ -60,7 +60,8 @@
                                 <!--remove the new pet -->
                               
                         </form:form>
-                        <form:form method="POST" action="/spring_framework_petclinic_war/pets/${pet.id}/view">
+                        <spring:url value="/pets/${pet.id}/view" var="petViewUrl" />
+                        <form:form method="POST" action="${fn:escapeXml(petViewUrl)}">
                             <button type="submit" name="viewPetDetails" value="${pet.id}">
                                     View Details
                                 </button>

--- a/src/test/java/org/springframework/samples/petclinic/web/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/web/OwnerControllerTests.java
@@ -6,13 +6,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.service.ClinicService;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.List;
+
 import static org.hamcrest.Matchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -214,11 +218,21 @@ class OwnerControllerTests {
 
     @Test
     void testProcessCancelOwnerAppointmentForm() throws Exception {
+        Visit visit1 = new Visit();
+        visit1.setId(1);
+        Visit visit3 = new Visit();
+        visit3.setId(3);
+
+        given(this.clinicService.findVisitsByOwnerId(TEST_OWNER_ID)).willReturn(Lists.newArrayList(visit1, visit3));
+
         mockMvc.perform(post("/owners/{ownerId}/appointments/cancel", TEST_OWNER_ID)
             .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
             .param("1", "on")
-            .param("2", "off")
+            .param("2", "on")
+            .param("3", "off")
         )
             .andExpect(status().is3xxRedirection());
+
+        then(clinicService).should().deleteVisitsById(Lists.newArrayList(1));
     }
 }


### PR DESCRIPTION
This prevents somebody from abusing the API endpoint to delete somebody else's appointments, and adds unit tests for the feature

Drive-by: fix a newly introduced hardcoded `/spring_framework_petclinic_war` URL.