### PR TITLE
bug(APPT-STQA-276): Fix checkGoBackButtonGoesBackCancelAppointment to not create a new appointment

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/web/AppointmentTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/web/AppointmentTest.java
@@ -2,7 +2,6 @@ package org.springframework.samples.petclinic.web;
 
 import io.github.bonigarcia.seljup.SeleniumExtension;
 import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,9 +9,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.samples.petclinic.web.WebTestsCommon.TOMCAT_PORT;
 import static org.springframework.samples.petclinic.web.WebTestsCommon.TOMCAT_PREFIX;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SeleniumExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -34,7 +29,6 @@ public class AppointmentTest {
     }
 
     @Test
-    @Order(1)
     void checkForCancelButton() {
 
         //assert
@@ -48,7 +42,6 @@ public class AppointmentTest {
     }
 
     @Test
-    @Order(2)
     void checkNumberOfCancelButtons() {
 
         driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/appointments/viewForm");
@@ -61,7 +54,6 @@ public class AppointmentTest {
     }
 
     @Test
-    @Order(3)
     void checkFirstCancelButtonIsID1() {
 
         driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/appointments/viewForm");
@@ -73,37 +65,22 @@ public class AppointmentTest {
     }
 
     @Test
-    @Order(4)
     void checkGoBackButtonGoesBackCancelAppointment() {
-        // get a date in the future
-        Calendar c = Calendar.getInstance();
-        c.setTime(new Date());
-        c.add(Calendar.YEAR, 3);
-
-        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/owners/1/pets/1/visits/new");
+        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/owners/6");
         driver.manage().window().maximize();
-
-        // create a visit to make the cancel button show up
-        WebElement date = driver.findElement(By.name("date"));
-        date.clear();
-        date.sendKeys(new SimpleDateFormat("yyyy/MM/dd").format(c.getTime()));
-        driver.findElement(By.tagName("h2")).click(); // dismiss the date picker
-        driver.findElement(By.name("description")).sendKeys("test");
-        driver.findElement(By.cssSelector("#visit button")).click();
 
         // click the cancel button and check we're on the cancel page
         driver.findElement(By.xpath("/html/body/div[1]/div/a[3]")).click();
-        assertThat(driver.getCurrentUrl(), endsWith("/owners/1/appointments/cancel.html"));
+        assertThat(driver.getCurrentUrl(), endsWith("/owners/6/appointments/cancel.html"));
 
         // click the back button and check we're back on the owner page
         driver.findElement(By.xpath("//*[@id=\"visits\"]/button[2]")).click();
-        assertThat(driver.getCurrentUrl(), endsWith("/owners/1"));
+        assertThat(driver.getCurrentUrl(), endsWith("/owners/6"));
     }
 
     //Used for the vetProfile page. Basically ensure that there's always a cancel
     //button for the appointments in the schedule. If there's none, there's no appointments.
     @Test
-    @Order(5)
     void checkAppointmentsScheduledCanBeCancelled() {
         driver.get("http://localhost:"+ TOMCAT_PORT+ TOMCAT_PREFIX+ "/vetProfile.html?id=4");
         driver.manage().window().maximize();
@@ -113,7 +90,6 @@ public class AppointmentTest {
     }
 
     @Test
-    @Order(6)
     void testVetVisitResultTable()
     {
         //arrange
@@ -135,7 +111,7 @@ public class AppointmentTest {
     }
 
     @Test
-    void checkOwnerAppointmentsTableExists() throws Exception{
+    void checkOwnerAppointmentsTableExists() {
         driver.get("http://localhost:"+TOMCAT_PORT + TOMCAT_PREFIX+"owners/6/appointments/viewForm");
         driver.manage().window().maximize();
 
@@ -144,7 +120,7 @@ public class AppointmentTest {
     }
 
     @Test
-    void checkOwnerAppointmentsRowsCount() throws Exception{
+    void checkOwnerAppointmentsRowsCount() {
         driver.get("http://localhost:"+TOMCAT_PORT + TOMCAT_PREFIX+"/owners/10/appointments/viewForm");
         driver.manage().window().maximize();
 


### PR DESCRIPTION
This is because as part of the test, an appointment is created but not deleted. `checkNumberOfCancelButtons` verifies that there is a certain amount of appointments. The work done for STQA-221 allows us to remove the code creating the appointment.