### PR TITLE
bug(YEET-SQTA-211): Deleting pet with rating throws exception

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Owner.java
@@ -79,7 +79,7 @@ public class Owner extends Person {
     @NotEmpty
     private String comment;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "owner")
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "owner", fetch = FetchType.EAGER)
     private Set<Pet> pets;
 
 

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
@@ -25,7 +25,6 @@ import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
-import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.OwnerRepository;
 import org.springframework.samples.petclinic.repository.PetRepository;
 import org.springframework.samples.petclinic.util.EntityUtils;
@@ -93,7 +92,8 @@ public class JdbcPetRepositoryImpl implements PetRepository {
             Number newKey = this.insertPet.executeAndReturnKey(
                 createPetParameterSource(pet));
             pet.setId(newKey.intValue());
-        } else {
+        }
+        else {
             this.namedParameterJdbcTemplate.update(
                 "UPDATE pets SET name=:name, birth_date=:birth_date, type_id=:type_id, " +
                     "owner_id=:owner_id WHERE id=:id",
@@ -141,12 +141,14 @@ public class JdbcPetRepositoryImpl implements PetRepository {
         params.put("id", id);
 
         // Cascade Delete visits
-        List<Visit> visits = pet.getVisits();
-        for (Visit visit : visits) {
-            Map<String, Object> visit_params = new HashMap<>();
-            visit_params.put("id", visit.getId());
-            this.namedParameterJdbcTemplate.update("DELETE FROM visits WHERE id=:id", visit_params);
-        }
+        Map<String, Object> visit_params = new HashMap<>();
+        visit_params.put("id", pet.getId());
+        this.namedParameterJdbcTemplate.update("DELETE FROM visits WHERE pet_id=:id", visit_params);
+
+        // Cascade Delete Rating
+        Map<String, Object> rating_params = new HashMap<>();
+        rating_params.put("id", pet.getId());
+        this.namedParameterJdbcTemplate.update("DELETE FROM ratings WHERE pet_id=:id", rating_params);
 
         String DELETE_PET = "delete from pets p WHERE p.id =:id";
         this.namedParameterJdbcTemplate.update(DELETE_PET, params);

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryImpl.java
@@ -70,21 +70,14 @@ public class JpaPetRepositoryImpl implements PetRepository {
         return this.em.createQuery("SELECT distinct pet FROM Pet pet ORDER BY pet.id").getResultList();
     }
 
-//    @Override
-//    @Transactional
-//    public void removePet(int petId) {
-//        // Black magic
-//        this.em.createQuery("DELETE FROM Pet p WHERE p.id=:petId")
-//            .setParameter("petId", petId)
-//            .executeUpdate();
-//    }
-
     @Override
     @Transactional
     public void removePet(Pet pet) {
         String petId = pet.getId().toString();
         // Cascade delete visit
         this.em.createQuery("DELETE FROM Visit visit WHERE pet_id=" + petId).executeUpdate();
+        // Cascade delete rating
+        this.em.createQuery("DELETE FROM Rating rating WHERE pet_id=" + petId).executeUpdate();
 
         this.em.createQuery("DELETE FROM Pet pet WHERE id=" + petId).executeUpdate();
         if (em.contains(pet)) {

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryImpl.java
@@ -21,6 +21,8 @@ public class SpringDataPetRepositoryImpl implements PetRepositoryOverride {
         String petId = pet.getId().toString();
         // Cascade delete visits
         this.em.createQuery("DELETE FROM Visit visit WHERE pet_id=" + petId).executeUpdate();
+        // Cascade delete rating
+        this.em.createQuery("DELETE FROM Rating rating WHERE pet_id=" + petId).executeUpdate();
 
         this.em.createQuery("DELETE FROM Pet pet WHERE id=" + petId).executeUpdate();
         if (em.contains(pet)) {

--- a/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceTests.java
@@ -32,10 +32,10 @@ import org.springframework.samples.petclinic.repository.PetRepository;
 import org.springframework.samples.petclinic.util.EntityUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDate;
 import java.util.*;
-import java.util.Arrays;
-import java.util.Collection;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
@@ -287,16 +287,23 @@ abstract class AbstractClinicServiceTests {
     void shouldRemoveSamanthaFromPetList() {
         int id = 7;
         // Arrange
+        Pet pet = EntityUtils.getById(this.clinicService.findPets(), Pet.class, id);
         Collection<Pet> actualPetList;
 
         // Act
-        this.clinicService.removePetById(id);
+        this.clinicService.removePetById(pet.getId());
         actualPetList = this.clinicService.findPets();
 
         // Assert
         assertThat(actualPetList.size()).isEqualTo(12);
         boolean result = actualPetList.stream().anyMatch(x -> x.getName().equalsIgnoreCase("Samantha"));
         assertFalse(result);
+
+        // Revert
+        Owner owner = this.clinicService.findOwnerById(pet.getOwner().getId());
+        owner.addPet(pet);
+        this.clinicService.savePet(pet);
+        this.clinicService.saveOwner(owner);
     }
 
     @Test
@@ -371,16 +378,16 @@ abstract class AbstractClinicServiceTests {
 
     @Test
     @Order(21)
-    void shouldFindAllAppointments(){
+    void shouldFindAllAppointments() {
 
         Collection<Visit> visits = this.clinicService.findAllVisits();
-        assertThat(visits.size()==4);
+        assertThat(visits.size() == 4);
     }
 
     @Test
     @Transactional
     @Order(20)
-    void shouldDeleteVisitById() throws Exception{
+    void shouldDeleteVisitById() throws Exception {
 
         int oldRows = this.clinicService.findAllVisits().size();
         MatcherAssert.assertThat(oldRows, is(6));
@@ -471,7 +478,6 @@ abstract class AbstractClinicServiceTests {
         assertThat(owners.isEmpty()).isFalse();
         assertThat(owners.size()).isEqualTo(10);
     }
-
 
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceTests.java
@@ -307,6 +307,29 @@ abstract class AbstractClinicServiceTests {
     }
 
     @Test
+    void shouldRemoveLeoFromPetList() {
+        int id = 1;
+        // Arrange
+        Pet pet = EntityUtils.getById(this.clinicService.findPets(), Pet.class, id);
+        Collection<Pet> actualPetList;
+
+        // Act
+        this.clinicService.removePetById(pet.getId());
+        actualPetList = this.clinicService.findPets();
+
+        // Assert
+        assertThat(actualPetList.size()).isEqualTo(12);
+        boolean result = actualPetList.stream().anyMatch(x -> x.getName().equalsIgnoreCase(pet.getName()));
+        assertFalse(result);
+
+        // Revert
+        Owner owner = this.clinicService.findOwnerById(pet.getOwner().getId());
+        owner.addPet(pet);
+        this.clinicService.savePet(pet);
+        this.clinicService.saveOwner(owner);
+    }
+
+    @Test
     @Order(23)
     void shouldExceptionWithPetNotExist() {
         int id = 69;

--- a/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceTests.java
@@ -300,14 +300,12 @@ abstract class AbstractClinicServiceTests {
         assertFalse(result);
 
         // Revert
-        Owner owner = this.clinicService.findOwnerById(pet.getOwner().getId());
-        owner.addPet(pet);
-        this.clinicService.savePet(pet);
-        this.clinicService.saveOwner(owner);
+        revertPet(pet);
     }
 
     @Test
     void shouldRemoveLeoFromPetList() {
+        boolean jdbcTest = this.getClass().equals(ClinicServiceJdbcTests.class);
         int id = 1;
         // Arrange
         Pet pet = EntityUtils.getById(this.clinicService.findPets(), Pet.class, id);
@@ -323,10 +321,7 @@ abstract class AbstractClinicServiceTests {
         assertFalse(result);
 
         // Revert
-        Owner owner = this.clinicService.findOwnerById(pet.getOwner().getId());
-        owner.addPet(pet);
-        this.clinicService.savePet(pet);
-        this.clinicService.saveOwner(owner);
+        revertPet(pet);
     }
 
     @Test
@@ -502,5 +497,22 @@ abstract class AbstractClinicServiceTests {
         assertThat(owners.size()).isEqualTo(10);
     }
 
+    private void revertPet(Pet pet) {
+        boolean jdbcTest = this.getClass().equals(ClinicServiceJdbcTests.class);
 
+        Owner owner = pet.getOwner();
+        owner.addPet(pet);
+        if (jdbcTest)
+            pet.setId(null);
+        this.clinicService.savePet(pet);
+        if (jdbcTest) {
+            this.clinicService.saveOwner(owner);
+            for (Visit visit : pet.getVisits()) {
+                this.clinicService.saveVisit(visit);
+            }
+            for (Rating rating : pet.getRatings()) {
+                this.clinicService.saveRating(rating);
+            }
+        }
+    }
 }


### PR DESCRIPTION
When trying to delete the pets that have a rating assigned to it, it will throw a fk constraint violation exception.
Fixed it by adding a cascade delete to remove the rating associated to that pet when removing a certain pet

Added a unit test to remove a pet that have a rating associated to it
Unit test result:
![image](https://user-images.githubusercontent.com/44531835/101224318-40fac700-365c-11eb-88eb-32428d818713.png)

Please review my code 😄 