### PR TITLE
bug(OWRT-STQA-284): Add missing dependencies from project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,27 @@
             <version>${aspectj.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+            <version>${aspectj.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.3</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-remote-driver</artifactId>
+            <version>3.141.59</version>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- Database connection pool
         See here for more details on commons-dbcp versus tomcat-jdbc:
         http://blog.ippon.fr/2013/03/13/improving-the-performance-of-the-spring-petclinic-sample-application-part-3-of-5/

--- a/pom.xml
+++ b/pom.xml
@@ -209,13 +209,6 @@
             <scope>compile</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-remote-driver</artifactId>
-            <version>3.141.59</version>
-            <scope>compile</scope>
-        </dependency>
-
         <!-- Database connection pool
         See here for more details on commons-dbcp versus tomcat-jdbc:
         http://blog.ippon.fr/2013/03/13/improving-the-performance-of-the-spring-petclinic-sample-application-part-3-of-5/


### PR DESCRIPTION
Some dependencies were missing from the pom.xml file. This caused the project from crashing on start until they were added back in. 

Here is the list of the missing dependencies:
**aspectjweaver:** https://mvnrepository.com/artifact/org.aspectj/aspectjweaver/1.9.6
**json-smart**: https://mvnrepository.com/artifact/net.minidev/json-smart/2.3
~~**selenium-remote-driver:** https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-remote-driver/3.141.59~~
Turns out the selenium-remote-driver was in conflict with Mockito and made all tests using it fail.