### PR TITLE
feat(YEET-SQTA-206): Redesign Pet List Page

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/pets/findPets.jsp
+++ b/src/main/webapp/WEB-INF/jsp/pets/findPets.jsp
@@ -10,6 +10,10 @@
 <petclinic:layout pageName="pets">
     <h2 id="pets">Pets</h2>
 
+    <label>
+        <input type="search" id="searchFilter" class="form-control" placeholder="Search" maxlength="20">
+    </label>
+
     <%--    Check if there's pets in the petclinic--%>
     <c:choose>
         <%--        There's at least one pet--%>
@@ -37,9 +41,6 @@
                             </spring:url>
                             <a href="${fn:escapeXml(petUrl)}">
                                 <button type="button" class="btn btn-link btnLink" style="padding: 5px">
-                                        <%--                                <span--%>
-                                        <%--                                        class="glyphicon glyphicon-pencil"--%>
-                                        <%--                                        aria-hidden="true"></span>--%>
                                     <span aria-hidden="true"><i class="fi-pencil"></i></span>
                                 </button>
                             </a>
@@ -96,9 +97,7 @@
     </c:choose>
 
     <input class="col-sm-3">
-    <%--    <a href="${fn:escapeXml(petUrl)}">--%>
-    <button type="button" name="addPet">Add Pet</button>
-    <%--    </a>--%>
+    <button type="button" name="addPet" onclick="return alert('Feature not implemented yet!')">Add Pet</button>
     <input type="text" id="addPet" name="addPet"><!--add the new pet -->
 
 </petclinic:layout>

--- a/src/main/webapp/WEB-INF/jsp/pets/findPets.jsp
+++ b/src/main/webapp/WEB-INF/jsp/pets/findPets.jsp
@@ -10,11 +10,11 @@
 <petclinic:layout pageName="pets">
     <h2 id="pets">Pets</h2>
 
-<%--    Check if there's pets in the petclinic--%>
+    <%--    Check if there's pets in the petclinic--%>
     <c:choose>
         <%--        There's at least one pet--%>
         <c:when test="${selections.toArray()[0] != null}">
-            <table id="petsTable" class="table table-striped" aria-describedby="pets">
+            <table id="petsTable" class="table table-striped table-hover" aria-describedby="pets">
                 <thead>
                 <tr>
                     <th scope="col">Name</th>
@@ -30,45 +30,57 @@
                 <c:forEach items="${selections}" var="pet">
                     <tr>
                         <td>
-                            <spring:url value="/owners/{ownerId}/pets/{petId}/edit" var="petUrl">
+                                <%--                            <spring:url value="/pets/${pet.id}/view" var="petViewUrl"/>--%>
+                                <%--                            <form:form method="POST" action="${fn:escapeXml(petViewUrl)}">--%>
+                                <%--                                <button type="submit" name="viewPetDetails" value="${pet.id}">--%>
+                                <%--                                    View Details--%>
+                                <%--                                </button>--%>
+                            <!--view details about pet -->
+
+                            <spring:url value="/owners/{ownerId}/pets/{petId}/view" var="detailUrl">
                                 <spring:param name="ownerId" value="${pet.owner.id}"/>
                                 <spring:param name="petId" value="${pet.id}"/>
                             </spring:url>
-                            <c:out value="${pet.name}"/>
+                            <a href="${fn:escapeXml(detailUrl)}"><c:out value="${pet.name}"/></a>
+                                <%--                            </form:form>--%>
                         </td>
                         <td>
                             <c:out value="${pet.birthDate}"/>
                         </td>
                         <td>
-                            <c:out value="${pet.owner.firstName} ${pet.owner.lastName}"/>
+                            <spring:url value="/owners/{ownerId}.html" var="ownerUrl">
+                                <spring:param name="ownerId" value="${pet.owner.id}"/>
+                            </spring:url>
+                            <a data-toggle="tooltip" data-html="true" data-placement="right"
+                               data-original-title="<img style='width:60%;' src='${pet.owner.profile_picture}' />"
+                               title="" class="ownerHover" href="${fn:escapeXml(ownerUrl)}">
+                                <c:out value="${pet.owner.firstName} ${pet.owner.lastName}"/>
+                            </a>
                         </td>
                         <td style="text-transform:capitalize;">
                             <c:out value="${pet.type.name}"/>
                         </td>
                         <td>
-                        <spring:url value="/pets/${pet.id}/remove" var="petRemoveUrl" />
-                        <form:form method="POST" action="${fn:escapeXml(petRemoveUrl)}">
-                            
-                              
-                              <a href="${fn:escapeXml(petUrl)}"><button type="button" name="editPet">Edit Pet Information</button></a>
-                            <!--    Go to edit pet page -->
-                              
-                                 <button type="submit" name="deletePet" value="${pet.id}"
+
+                            <spring:url value="/owners/{ownerId}/pets/{petId}/edit" var="petUrl">
+                                <spring:param name="ownerId" value="${pet.owner.id}"/>
+                                <spring:param name="petId" value="${pet.id}"/>
+                            </spring:url>
+                            <a href="${fn:escapeXml(petUrl)}">
+                                <button type="button" name="editPet">Edit Pet Information</button>
+                            </a>
+                            <!-- Go to edit pet page -->
+
+                            <spring:url value="/pets/${pet.id}/remove" var="petRemoveUrl"/>
+                            <form:form method="POST" action="${fn:escapeXml(petRemoveUrl)}"
+                                       cssStyle="display: inline-block">
+                                <button type="submit" name="deletePet" value="${pet.id}"
                                         onclick="return confirm('Are you sure you want to remove ${pet.name} from the system')">
                                     Delete Pet
                                 </button>
                                 <!--remove the new pet -->
-                              
-                        </form:form>
-                        <spring:url value="/pets/${pet.id}/view" var="petViewUrl" />
-                        <form:form method="POST" action="${fn:escapeXml(petViewUrl)}">
-                            <button type="submit" name="viewPetDetails" value="${pet.id}">
-                                    View Details
-                                </button>
-                                <!--view details about pet -->
-                          
-                            
-                        </form:form>
+
+                            </form:form>
                         </td>
                     </tr>
                 </c:forEach>
@@ -83,10 +95,10 @@
     </c:choose>
 
     <input class="col-sm-3">
-        <a href="${fn:escapeXml(petUrl)}">
-            <button type="button" name="addPet">Add Pet</button>
-        </a>
-        <input type="text" id="addPet" name="addPet"><!--add the new pet --></input>
+    <a href="${fn:escapeXml(petUrl)}">
+        <button type="button" name="addPet">Add Pet</button>
+    </a>
+    <input type="text" id="addPet" name="addPet"><!--add the new pet --></input>
     </div>
 
 </petclinic:layout>

--- a/src/main/webapp/WEB-INF/jsp/pets/findPets.jsp
+++ b/src/main/webapp/WEB-INF/jsp/pets/findPets.jsp
@@ -17,12 +17,12 @@
             <table id="petsTable" class="table table-striped table-hover" aria-describedby="pets">
                 <thead>
                 <tr>
+                    <th scope="col" style="width: 30px;"></th>
                     <th scope="col">Name</th>
                     <th scope="col">Birth Day</th>
                     <th scope="col">Owner</th>
                     <th scope="col">Type</th>
-                    <th></th>
-                    <th></th>
+                    <th scope="col" style="width: 30px;"></th>
 
                 </tr>
                 </thead>
@@ -30,19 +30,29 @@
                 <c:forEach items="${selections}" var="pet">
                     <tr>
                         <td>
-                                <%--                            <spring:url value="/pets/${pet.id}/view" var="petViewUrl"/>--%>
-                                <%--                            <form:form method="POST" action="${fn:escapeXml(petViewUrl)}">--%>
-                                <%--                                <button type="submit" name="viewPetDetails" value="${pet.id}">--%>
-                                <%--                                    View Details--%>
-                                <%--                                </button>--%>
-                            <!--view details about pet -->
+                            <!-- Edit Pet -->
+                            <spring:url value="/owners/{ownerId}/pets/{petId}/edit" var="petUrl">
+                                <spring:param name="ownerId" value="${pet.owner.id}"/>
+                                <spring:param name="petId" value="${pet.id}"/>
+                            </spring:url>
+                            <a href="${fn:escapeXml(petUrl)}">
+                                <button type="button" class="btn btn-link btnLink" style="padding: 5px">
+                                        <%--                                <span--%>
+                                        <%--                                        class="glyphicon glyphicon-pencil"--%>
+                                        <%--                                        aria-hidden="true"></span>--%>
+                                    <span aria-hidden="true"><i class="fi-pencil"></i></span>
+                                </button>
+                            </a>
+                        </td>
+                        <td>
 
+                            <!--view details about pet -->
                             <spring:url value="/owners/{ownerId}/pets/{petId}/view" var="detailUrl">
                                 <spring:param name="ownerId" value="${pet.owner.id}"/>
                                 <spring:param name="petId" value="${pet.id}"/>
                             </spring:url>
-                            <a href="${fn:escapeXml(detailUrl)}"><c:out value="${pet.name}"/></a>
-                                <%--                            </form:form>--%>
+                            <a href="${fn:escapeXml(detailUrl)}" style="font-weight: bold;"><c:out
+                                    value="${pet.name}"/></a>
                         </td>
                         <td>
                             <c:out value="${pet.birthDate}"/>
@@ -61,22 +71,13 @@
                             <c:out value="${pet.type.name}"/>
                         </td>
                         <td>
-
-                            <spring:url value="/owners/{ownerId}/pets/{petId}/edit" var="petUrl">
-                                <spring:param name="ownerId" value="${pet.owner.id}"/>
-                                <spring:param name="petId" value="${pet.id}"/>
-                            </spring:url>
-                            <a href="${fn:escapeXml(petUrl)}">
-                                <button type="button" name="editPet">Edit Pet Information</button>
-                            </a>
-                            <!-- Go to edit pet page -->
-
                             <spring:url value="/pets/${pet.id}/remove" var="petRemoveUrl"/>
                             <form:form method="POST" action="${fn:escapeXml(petRemoveUrl)}"
                                        cssStyle="display: inline-block">
-                                <button type="submit" name="deletePet" value="${pet.id}"
-                                        onclick="return confirm('Are you sure you want to remove ${pet.name} from the system')">
-                                    Delete Pet
+                                <button type="submit" name="deletePet" class="btn btn-link btnLink" value="${pet.id}"
+                                        onclick="return confirm('Are you sure you want to remove ${pet.name} from the system')"
+                                        style="padding: 5px">
+                                    <span aria-hidden="true"><i class="fi-trash"></i></span>
                                 </button>
                                 <!--remove the new pet -->
 
@@ -95,11 +96,10 @@
     </c:choose>
 
     <input class="col-sm-3">
-    <a href="${fn:escapeXml(petUrl)}">
-        <button type="button" name="addPet">Add Pet</button>
-    </a>
-    <input type="text" id="addPet" name="addPet"><!--add the new pet --></input>
-    </div>
+    <%--    <a href="${fn:escapeXml(petUrl)}">--%>
+    <button type="button" name="addPet">Add Pet</button>
+    <%--    </a>--%>
+    <input type="text" id="addPet" name="addPet"><!--add the new pet -->
 
 </petclinic:layout>
 

--- a/src/main/webapp/WEB-INF/tags/footer.tag
+++ b/src/main/webapp/WEB-INF/tags/footer.tag
@@ -68,4 +68,6 @@
 <script src="${hofJS}"></script>
 <spring:url value="/resources/javascript/GoToTopJavascript.js" var="backToTopJs"/>
 <script src="${backToTopJs}"></script>
+<spring:url value="/resources/javascript/PetPage.js" var="petPageJs"/>
+<script src="${petPageJs}"></script>
 

--- a/src/main/webapp/WEB-INF/tags/htmlHeader.tag
+++ b/src/main/webapp/WEB-INF/tags/htmlHeader.tag
@@ -35,14 +35,18 @@ PetClinic :: a Spring Framework demonstration
     <link href="${hallOfFame}" rel="stylesheet">
 
     <%-- Css added for showing pet information in hall of fame #Simon St-Andre --%>
-    <spring:url value="/resources/css/petInfoCard.css" var="cardInfo" />
+    <spring:url value="/resources/css/petInfoCard.css" var="cardInfo"/>
     <link href="${cardInfo}" rel="stylesheet">
 
-    <spring:url value="/resources/css/headerPage.css" var="headerCss" />
+    <spring:url value="/resources/css/headerPage.css" var="headerCss"/>
     <link href="${headerCss}" rel="stylesheet">
 
-    <spring:url value="/resources/css/footer.css" var="footerCss" />
+    <spring:url value="/resources/css/footer.css" var="footerCss"/>
     <link href="${footerCss}" rel="stylesheet">
+
+    <%-- Css for Pet Page #Simon St-Andre --%>
+    <spring:url value="/resources/css/petPage.css" var="petPageCss"/>
+    <link href="${petPageCss}" rel="stylesheet">
     <%-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries --%>
     <!--[if lt IE 9]>
     <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>

--- a/src/main/webapp/resources/css/petPage.css
+++ b/src/main/webapp/resources/css/petPage.css
@@ -1,0 +1,15 @@
+.tooltip.in {
+    opacity: 1 !important;
+}
+
+.ownerHover {
+    color: #34302d;
+    text-decoration: underline;
+    text-underline-position: under;
+    text-decoration-style: dashed;
+}
+
+.ownerHover:hover {
+    color: #5fa134;
+    text-decoration-style: dashed;
+}

--- a/src/main/webapp/resources/css/petPage.css
+++ b/src/main/webapp/resources/css/petPage.css
@@ -13,3 +13,12 @@
     color: #5fa134;
     text-decoration-style: dashed;
 }
+
+.btnLink:hover {
+    filter: brightness(85%);
+}
+
+#petsTable td {
+    height: 30px;
+    line-height: 30px;
+}

--- a/src/main/webapp/resources/javascript/PetPage.js
+++ b/src/main/webapp/resources/javascript/PetPage.js
@@ -1,0 +1,5 @@
+$(function () {
+    $('[data-toggle="tooltip"]').tooltip({
+        container: 'body'
+    });
+});

--- a/src/main/webapp/resources/javascript/PetPage.js
+++ b/src/main/webapp/resources/javascript/PetPage.js
@@ -1,5 +1,51 @@
+let $tableSize;
+
 $(function () {
+    $tableSize = $("tbody tr").length;
+
     $('[data-toggle="tooltip"]').tooltip({
         container: 'body'
     });
+
+    // Search bar on input listener
+    $("#searchFilter").on("input", searchOperations);
 });
+
+/**
+ * Credit to @Ryan for the search function
+ */
+// Function to search the operations
+function searchOperations() {
+    let searchText = $("#searchFilter").val().toLowerCase(); // User-inputted search text
+
+    let name; // Field name to compare
+
+    // Loops each row of the table <tr>
+    for (let i = 1; i <= $tableSize; i++) {
+        let found = false;
+
+        // Loops each column of the table <td>
+        // Starting at 2 because td(1) is the Update button
+        for (let j = 1; j <= $("tbody tr:nth-child(" + i + ") td").length; j++) {
+            name = $("tbody tr:nth-child(" + i + ") td:eq(" + j + ")").text().toLowerCase();
+            if (name.search(searchText) !== -1) {
+                found = true;
+                break;
+            }
+        }
+
+        // Search Employee Name to find any occurrence of the Search Input
+        // Show them if found
+        if (found) {
+            if (!$("tbody tr:nth-child(" + i + ")").is(":visible")) {
+                $("tbody tr:nth-child(" + i + ")").show();
+            }
+        }
+        // Hide them if not found
+        else {
+            if ($("tbody tr:nth-child(" + i + ")").is(":visible")) {
+                $("tbody tr:nth-child(" + i + ")").hide();
+            }
+        }
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/web/AppointmentTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/web/AppointmentTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.openqa.selenium.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -37,8 +39,8 @@ public class AppointmentTest {
         driver.manage().window().maximize();
 
         //get list all elements within footer tag.
-        WebElement cancel= driver.findElement(By.xpath("//input[@type='submit']"));
-        assertThat(cancel.isDisplayed(), is(true)) ;
+        WebElement cancel = driver.findElement(By.xpath("//input[@type='submit']"));
+        assertThat(cancel.isDisplayed(), is(true));
 
     }
 
@@ -83,7 +85,7 @@ public class AppointmentTest {
     //button for the appointments in the schedule. If there's none, there's no appointments.
     @Test
     void checkAppointmentsScheduledCanBeCancelled() {
-        driver.get("http://localhost:"+ TOMCAT_PORT+ TOMCAT_PREFIX+ "/vetProfile.html?id=4");
+        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/vetProfile.html?id=4");
         driver.manage().window().maximize();
 
         List<WebElement> hasASchedule = driver.findElements(By.className("btn"));
@@ -91,8 +93,7 @@ public class AppointmentTest {
     }
 
     @Test
-    void testVetVisitResultTable()
-    {
+    void testVetVisitResultTable() {
         //arrange
         driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/vetProfile.html?id=1");
         driver.manage().window().maximize();
@@ -113,7 +114,7 @@ public class AppointmentTest {
 
     @Test
     void checkOwnerAppointmentsTableExists() {
-        driver.get("http://localhost:"+TOMCAT_PORT + TOMCAT_PREFIX+"owners/6/appointments/viewForm");
+        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/owners/6/appointments/viewForm");
         driver.manage().window().maximize();
 
         WebElement table = driver.findElement(By.xpath("//table"));
@@ -122,7 +123,7 @@ public class AppointmentTest {
 
     @Test
     void checkOwnerAppointmentsRowsCount() {
-        driver.get("http://localhost:"+TOMCAT_PORT + TOMCAT_PREFIX+"/owners/10/appointments/viewForm");
+        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/owners/10/appointments/viewForm");
         driver.manage().window().maximize();
 
         int count = driver.findElements(By.xpath("//tr")).size();
@@ -132,7 +133,7 @@ public class AppointmentTest {
     }
 
     @Test
-    void checkAppointmentCancelConfirmation(){
+    void checkAppointmentCancelConfirmation() {
 
         driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/appointments/viewForm");
         driver.manage().window().maximize();
@@ -150,7 +151,6 @@ public class AppointmentTest {
         }
 
         assertThat(foundAlert, is(true));
-
 
 
     }

--- a/src/test/java/org/springframework/samples/petclinic/web/PetPageTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/web/PetPageTest.java
@@ -127,4 +127,21 @@ public class PetPageTest {
 
         assertThat(driver.findElementByXPath("//div[@role='tooltip']").isDisplayed(), is(true));
     }
+
+    @Test
+    void shouldSearchCorrectPet() {
+        // Arrange
+        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/pets/find.html");
+        driver.manage().window().maximize();
+
+        // Act & Assert
+        driver.findElementById("searchFilter").sendKeys("Mul");
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        assertThat(driver.findElementByXPath("//a[contains(text(), 'Mulligan')]").isDisplayed(), is(true));
+    }
 }

--- a/src/test/java/org/springframework/samples/petclinic/web/PetPageTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/web/PetPageTest.java
@@ -1,0 +1,130 @@
+package org.springframework.samples.petclinic.web;
+
+import io.github.bonigarcia.seljup.SeleniumExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.Select;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.samples.petclinic.web.WebTestsCommon.TOMCAT_PORT;
+import static org.springframework.samples.petclinic.web.WebTestsCommon.TOMCAT_PREFIX;
+
+@ExtendWith(SeleniumExtension.class)
+public class PetPageTest {
+
+    ChromeDriver driver;
+
+    public PetPageTest(ChromeDriver driver) {
+        this.driver = driver;
+    }
+
+    @Test
+    void shouldGoToEdit() {
+        // Arrange
+        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/pets/find.html");
+        driver.manage().window().maximize();
+
+        // Act & Assert
+        driver.findElement(By.xpath("//a[contains(@href, '/owners/5/pets/6/edit')]")).click();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        assertThat(driver.findElementByXPath("//input[@value='George']").isDisplayed(), is(true));
+    }
+
+    @Test
+    void shouldGoToDetailView() {
+        // Arrange
+        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/pets/find.html");
+        driver.manage().window().maximize();
+
+        // Act & Assert
+        driver.findElement(By.xpath("//a[contains(text(), 'Iggy')]")).click();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        assertThat(driver.findElement(By.xpath("//strong[contains(text(), 'Iggy')]")).isDisplayed(), is(true));
+        assertThat(driver.findElement(By.xpath("//strong[contains(text(), 'Harold Davis')]")).isDisplayed(), is(true));
+        assertThat(driver.findElement(By.xpath("//strong[contains(text(), 'lizard')]")).isDisplayed(), is(true));
+    }
+
+    @Test
+    void shouldDeletePet() {
+        // Arrange
+        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/pets/find.html");
+        driver.manage().window().maximize();
+
+        // Act & Assert
+        driver.findElement(By.xpath("//button[@value=5]")).click();
+        try {
+            Thread.sleep(1000);
+            driver.switchTo().alert().accept();
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        assertThat(driver.getCurrentUrl(), endsWith("/pets/find"));
+        // Revert
+        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/owners/4/pets/new.html");
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        driver.findElementByName("name").sendKeys("Iggy");
+        driver.findElementByName("birthDate").sendKeys("2010/11/30");
+        driver.findElementByName("birthDate").sendKeys(Keys.TAB);
+        Select select = new Select(driver.findElementByName("type"));
+        select.selectByVisibleText("lizard");
+        driver.findElement(By.xpath("//button[@type='submit']")).click();
+    }
+
+    @Test
+    void shouldShowOwner() {
+        // Arrange
+        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/pets/find.html");
+        driver.manage().window().maximize();
+
+        // Act & Assert
+        driver.findElement(By.xpath("//a[contains(text(), 'Jeff Black')]")).click();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        assertThat(driver.findElementByXPath("//strong[contains(text(), 'Jeff Black')]").isDisplayed(), is(true));
+        assertThat(driver.findElementByXPath("//td[@headers='email']").getText(), is("jeff.black@gmail.com"));
+        assertThat(driver.getCurrentUrl(), endsWith("/owners/7.html"));
+    }
+
+    @Test
+    void shouldShowToolTip() {
+        // Arrange
+        driver.get("http://localhost:" + TOMCAT_PORT + TOMCAT_PREFIX + "/pets/find.html");
+        driver.manage().window().maximize();
+
+        // Act & Assert
+        new Actions(driver).moveToElement(driver.findElement(By.xpath("//a[contains(text(), 'Jeff Black')]"))).build().perform();
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        assertThat(driver.findElementByXPath("//div[@role='tooltip']").isDisplayed(), is(true));
+    }
+}


### PR DESCRIPTION
Redesigned the pet list page to make it more intuitive

Please review my code 😺 

Requirements:
- Clicking a pet’s name should redirect to pet details page
- Hovering on an owner’s name will display their profile picture
- Delete pet should be an icon beside the pet’s name
- Edit pet should also be an icon instead
- Clicking on the owner’s name redirect to that owner’s page
- Search for specific pet by entering some value

End-To-End testing results:
![image](https://user-images.githubusercontent.com/44531835/101294302-72060380-37e4-11eb-9108-0a2295e0090c.png)

Regression Test Results:
![image](https://user-images.githubusercontent.com/44531835/101294262-353a0c80-37e4-11eb-8d12-dc1ed6349d8a.png)
