### PR TITLE
bug(OWRT-STQA-213): Add profile_picture field in JSON file

### DIFF
--- a/src/main/resources/uploads/success.json
+++ b/src/main/resources/uploads/success.json
@@ -7,7 +7,8 @@
         "telephone": "6085555418",
         "email": "joseph.smith@gmail.com",
         "comment": "Does not like green",
-        "state": "QC"
+        "state": "QC",
+        "profile_picture": "images_default"
     },
     {
         "firstName": "James",
@@ -17,7 +18,8 @@
         "telephone": "6085544418",
         "email": "james.blaese@gmail.com",
         "comment": "Does not like red",
-        "state": "QC"
+        "state": "QC",
+        "profile_picture": "images_default"
     },
     {
         "firstName": "Daniel",
@@ -27,7 +29,8 @@
         "telephone": "6085544418",
         "email": "daniel.williams@gmail.com",
         "comment": "Does not like blue",
-        "state": "QC"
+        "state": "QC",
+        "profile_picture": "images_default"
     },
     {
         "firstName": "Joshua",
@@ -37,6 +40,7 @@
         "telephone": "6083344418",
         "email": "joshua.davis@gmail.com",
         "comment": "Does not like red",
-        "state": "QC"
+        "state": "QC",
+        "profile_picture": "images_default"
     }
 ]


### PR DESCRIPTION
Since a new field has been added in the Owner entity, I needed to add that field in the JSON file that I am using in order to test my file upload features, otherwise the system would throw an error.

Here is how the 
`{
        "firstName": "Joseph",
        "lastName": "Smith",
        "address": "123 A road",
        "city": "Montreal",
        "telephone": "6085555418",
        "email": "joseph.smith@gmail.com",
        "comment": "Does not like green",
        "state": "QC",
        "profile_picture": "images_default"
    }`